### PR TITLE
prefix instead of runid

### DIFF
--- a/supermeans.py
+++ b/supermeans.py
@@ -28,7 +28,7 @@ args = parser.parse_args()
 runid=args.runid
 print('runid is', runid)
 
-prefix=args.runid
+prefix=args.prefix
 print('raw data file prefix is ', prefix)
 
 in_dir=args.in_dir


### PR DESCRIPTION
Changed the `runid` to `prefix` so that it reads the files correctly. 